### PR TITLE
Show decimal value in __repr__ for money field objects

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -140,9 +140,7 @@ class MoneyPatched(Money):
         return format_money(self)
 
     def __repr__(self):
-        # small fix for tests
-        return "%s %s" % (self.amount.to_integral_value(ROUND_DOWN),
-                          self.currency)
+        return "%s %s" % (float(self.amount), self.currency)
 
 
 class MoneyFieldProxy(object):


### PR DESCRIPTION
This is really annoying when writing tests in the jobs apps, since the
unit test failures report money differences as rounding down. Often
you'll just see `0 USD != 0 USD`
